### PR TITLE
Outlet initializer

### DIFF
--- a/examples/cfd/grid_refinement/cuboid_flow_past_sphere_3d.py
+++ b/examples/cfd/grid_refinement/cuboid_flow_past_sphere_3d.py
@@ -216,12 +216,24 @@ boundary_conditions = [bc_walls, bc_left, bc_outlet, bc_sphere]
 visc = u_max * num_finest_voxels_across_part / Re
 omega = 1.0 / (3.0 * visc + 0.5)
 
+# Make initializer operator
+from xlb.helper.initializers import MultiresOutletInitializer
+
+initializer = MultiresOutletInitializer(
+    outlet_bc_id=bc_outlet.id,
+    wind_vector=(u_max, 0.0, 0.0),
+    velocity_set=velocity_set,
+    precision_policy=precision_policy,
+    compute_backend=compute_backend,
+)
+
 # Define a multi-resolution simulation manager
 sim = xlb.helper.MultiresSimulationManager(
     omega=omega,
     grid=grid,
     boundary_conditions=boundary_conditions,
     collision_type="KBC",
+    initializer=initializer,
 )
 
 # Setup Momentum Transfer for Force Calculation

--- a/examples/cfd/rotating_sphere_3d.py
+++ b/examples/cfd/rotating_sphere_3d.py
@@ -148,8 +148,8 @@ stepper = IncompressibleNavierStokesStepper(
 from xlb.helper.initializers import OutletInitializer
 
 initializer = OutletInitializer(
-    wind_speed=wind_speed,
-    grid_shape=grid_shape,
+    outlet_bc_id=bc_do_nothing.id,
+    wind_vector=(wind_speed, 0.0, 0.0),
     velocity_set=velocity_set,
     precision_policy=precision_policy,
     compute_backend=compute_backend,

--- a/xlb/helper/initializers.py
+++ b/xlb/helper/initializers.py
@@ -5,6 +5,7 @@ from xlb.velocity_set import VelocitySet
 from xlb.compute_backend import ComputeBackend
 from xlb.operator.equilibrium import QuadraticEquilibrium
 from xlb.operator.equilibrium import MultiresQuadraticEquilibrium
+import neon
 
 
 def initialize_eq(f, grid, velocity_set, precision_policy, compute_backend, rho=None, u=None):
@@ -38,53 +39,96 @@ def initialize_multires_eq(f, grid, velocity_set, precision_policy, backend, rho
 class OutletInitializer(Operator):
     def __init__(
         self,
-        wind_speed=None,
-        grid_shape=None,
+        outlet_bc_id: int = None,
+        wind_vector=None,
         velocity_set: VelocitySet = None,
         precision_policy=None,
         compute_backend=None,
     ):
-        self.wind_speed = wind_speed
+        assert outlet_bc_id is not None, "Outlet BC ID must be provided."
+        self.outlet_bc_id = outlet_bc_id
+        self.wind_vector = wind_vector
         self.rho = 1.0
-        self.grid_shape = grid_shape
-        self.equilibrium = QuadraticEquilibrium(velocity_set=velocity_set, precision_policy=precision_policy, compute_backend=compute_backend)
+        self.equilibrium = QuadraticEquilibrium(
+            velocity_set=velocity_set,
+            precision_policy=precision_policy,
+            compute_backend=ComputeBackend.WARP,
+        )
         super().__init__(velocity_set, precision_policy, compute_backend)
 
     def _construct_warp(self):
-        nx, ny, nz = self.grid_shape
         _q = self.velocity_set.q
         _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
+        _u = _u_vec(self.wind_vector[0], self.wind_vector[1], self.wind_vector[2])
         _rho = self.compute_dtype(self.rho)
-        _u = _u_vec(self.wind_speed, 0.0, 0.0)
         _w = self.velocity_set.w
+        outlet_bc_id = self.outlet_bc_id
+
+        @wp.func
+        def functional(index: Any, bc_mask: Any, f_field: Any):
+            # Check if the index corresponds to the outlet
+            if self.read_field(bc_mask, index, 0) == outlet_bc_id:
+                _feq = self.equilibrium.warp_functional(_rho, _u)
+                for l in range(_q):
+                    self.write_field(f_field, index, l, _feq[l])
+            else:
+                # In the rest of the domain, we assume zero velocity and equilibrium distribution.
+                for l in range(_q):
+                    self.write_field(f_field, index, l, _w[l])
 
         # Construct the warp kernel
         @wp.kernel
-        def kernel(f: wp.array4d(dtype=Any)):
+        def kernel(
+            bc_mask: wp.array4d(dtype=wp.uint8),
+            f_field: wp.array4d(dtype=Any),
+        ):
             # Get the global index
             i, j, k = wp.tid()
             index = wp.vec3i(i, j, k)
 
             # Set the velocity at the outlet (i.e. where i = nx-1)
-            if index[0] == nx - 1:
-                _feq = self.equilibrium.warp_functional(_rho, _u)
-                for l in range(_q):
-                    f[l, index[0], index[1], index[2]] = _feq[l]
-            else:
-                # In the rest of the domain, we assume zero velocity and equilibrium distribution.
-                for l in range(_q):
-                    f[l, index[0], index[1], index[2]] = _w[l]
+            functional(index, bc_mask, f_field)
 
         return None, kernel
 
     @Operator.register_backend(ComputeBackend.WARP)
-    def warp_implementation(self, f):
+    def warp_implementation(self, bc_mask, f_field):
         # Launch the warp kernel
         wp.launch(
             self.warp_kernel,
-            inputs=[
-                f,
-            ],
-            dim=f.shape[1:],
+            inputs=[bc_mask, f_field],
+            dim=f_field.shape[1:],
         )
-        return f
+        return f_field
+
+    def _construct_neon(self):
+        # Use the warp functional for the NEON backend
+        functional, _ = self._construct_warp()
+
+        @neon.Container.factory(name="OutletInitializer")
+        def container(
+            bc_mask: Any,
+            f_field: Any,
+        ):
+            def launcher(loader: neon.Loader):
+                loader.set_grid(f_field.get_grid())
+                f_field_pn = loader.get_write_handle(f_field)
+                bc_mask_pn = loader.get_read_handle(bc_mask)
+
+                @wp.func
+                def kernel(index: Any):
+                    # apply the functional
+                    functional(index, bc_mask_pn, f_field_pn)
+
+                loader.declare_kernel(kernel)
+
+            return launcher
+
+        return _, container
+
+    @Operator.register_backend(ComputeBackend.NEON)
+    def neon_implementation(self, bc_mask, f_field, stream=0):
+        # Launch the neon container
+        c = self.neon_container(bc_mask, f_field)
+        c.run(stream, container_runtime=neon.Container.ContainerRuntime.neon)
+        return f_field

--- a/xlb/helper/initializers.py
+++ b/xlb/helper/initializers.py
@@ -89,7 +89,7 @@ class OutletInitializer(Operator):
             # Set the velocity at the outlet (i.e. where i = nx-1)
             functional(index, bc_mask, f_field)
 
-        return None, kernel
+        return functional, kernel
 
     @Operator.register_backend(ComputeBackend.WARP)
     def warp_implementation(self, bc_mask, f_field):
@@ -131,4 +131,52 @@ class OutletInitializer(Operator):
         # Launch the neon container
         c = self.neon_container(bc_mask, f_field)
         c.run(stream, container_runtime=neon.Container.ContainerRuntime.neon)
+        return f_field
+
+
+# Defining an initializer for outlet only
+class MultiresOutletInitializer(OutletInitializer):
+    def __init__(
+        self,
+        outlet_bc_id: int = None,
+        wind_vector=None,
+        velocity_set: VelocitySet = None,
+        precision_policy=None,
+        compute_backend=None,
+    ):
+        super().__init__(outlet_bc_id, wind_vector, velocity_set, precision_policy, compute_backend)
+
+    def _construct_neon(self):
+        # Use the warp functional for the NEON backend
+        functional, _ = self._construct_warp()
+
+        @neon.Container.factory(name="MultiresOutletInitializer")
+        def container(
+            bc_mask: Any,
+            f_field: Any,
+            level: Any,
+        ):
+            def launcher(loader: neon.Loader):
+                loader.set_mres_grid(f_field.get_grid(), level)
+                f_field_pn = loader.get_mres_write_handle(f_field)
+                bc_mask_pn = loader.get_mres_read_handle(bc_mask)
+
+                @wp.func
+                def kernel(index: Any):
+                    # apply the functional
+                    functional(index, bc_mask_pn, f_field_pn)
+
+                loader.declare_kernel(kernel)
+
+            return launcher
+
+        return _, container
+
+    @Operator.register_backend(ComputeBackend.NEON)
+    def neon_implementation(self, bc_mask, f_field, stream=0):
+        grid = bc_mask.get_grid()
+        for level in range(grid.num_levels):
+            # Launch the neon container
+            c = self.neon_container(bc_mask, f_field, level)
+            c.run(stream, container_runtime=neon.Container.ContainerRuntime.neon)
         return f_field

--- a/xlb/helper/simulation_manager.py
+++ b/xlb/helper/simulation_manager.py
@@ -17,9 +17,11 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
         collision_type="BGK",
         forcing_scheme="exact_difference",
         force_vector=None,
+        initializer=None,
     ):
         super().__init__(grid, boundary_conditions, collision_type, forcing_scheme, force_vector)
 
+        self.initializer = initializer
         self.omega = omega
         self.count_levels = grid.count_levels
         # Create fields
@@ -38,7 +40,7 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
         # self.u.export_vti(f"u_{fname_prefix}_topology.vti", 'u')
 
         # Prepare fields
-        self.f_0, self.f_1, self.bc_mask, self.missing_mask = self.prepare_fields(self.rho, self.u)
+        self.f_0, self.f_1, self.bc_mask, self.missing_mask = self.prepare_fields(self.rho, self.u, self.initializer)
         self.prepare_coalescence_count(coalescence_factor=self.coalescence_factor, bc_mask=self.bc_mask)
 
         # wp.synchronize()

--- a/xlb/operator/stepper/nse_multires_stepper.py
+++ b/xlb/operator/stepper/nse_multires_stepper.py
@@ -67,10 +67,6 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
         missing_mask = self.grid.create_field(cardinality=self.velocity_set.q, dtype=Precision.UINT8)
         bc_mask = self.grid.create_field(cardinality=1, dtype=Precision.UINT8)
 
-        from xlb.helper.initializers import initialize_multires_eq
-
-        f_0 = initialize_multires_eq(f_0, self.grid, self.velocity_set, self.precision_policy, self.compute_backend, rho=rho, u=u)
-
         for level in range(self.grid.count_levels):
             f_1.copy_from_run(level, f_0, 0)
         # f_0.update_host(0)
@@ -88,6 +84,15 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
         # bc_mask.export_vti("bc_mask.vti", "bc_mask")
         # f_0.export_vti("init_f0.vti", 'init_f0')
         # missing_mask.export_vti("missing_mask.vti", 'missing_mask')
+
+        # Initialize distribution functions if initializer is provided
+        if initializer is not None:
+            # Refer to xlb.helper.initializers for available initializers
+            f_0 = initializer(bc_mask, f_0)
+        else:
+            from xlb.helper.initializers import initialize_multires_eq
+
+            f_0 = initialize_multires_eq(f_0, self.grid, self.velocity_set, self.precision_policy, self.compute_backend, rho=rho, u=u)
 
         return f_0, f_1, bc_mask, missing_mask
 

--- a/xlb/operator/stepper/nse_stepper.py
+++ b/xlb/operator/stepper/nse_stepper.py
@@ -77,14 +77,6 @@ class IncompressibleNavierStokesStepper(Stepper):
             grid=self.grid, velocity_set=self.velocity_set, compute_backend=self.compute_backend, precision_policy=self.precision_policy
         )
 
-        # Initialize distribution functions if initializer is provided
-        if initializer is not None:
-            f_0 = initializer(f_0)
-        else:
-            from xlb.helper.initializers import initialize_eq
-
-            f_0 = initialize_eq(f_0, self.grid, self.velocity_set, self.precision_policy, self.compute_backend)
-
         # Copy f_0 using backend-specific copy to f_1
         if self.compute_backend == ComputeBackend.JAX:
             f_1 = f_0.copy()
@@ -92,35 +84,8 @@ class IncompressibleNavierStokesStepper(Stepper):
             wp.copy(f_1, f_0)
         if self.compute_backend == ComputeBackend.NEON:
             f_1.copy_from_run(f_0, 0)
-        if True:
-            import xlb.velocity_set
-            from xlb.operator.macroscopic import Macroscopic
 
-            # macro = Macroscopic(
-            #     compute_backend=ComputeBackend.NEON,
-            #     precision_policy=self.precision_policy,
-            #     velocity_set=xlb.velocity_set.D3Q19(precision_policy=self.precision_policy, backend=ComputeBackend.NEON),
-            # )
-            rho = self.grid.create_field(1, dtype=self.precision_policy.store_precision)
-            u = self.grid.create_field(3, dtype=self.precision_policy.store_precision)
-            # rho, u = macro(f_0, rho, u)
-            # wp.synchronize()
-            # wp.synchronize()
-            # u.update_host(0)
-            # rho.update_host(0)
-            # wp.synchronize()
-            # u.export_vti("u_init.vti", 'u')
-            # rho.export_vti("rho_init.vti", 'rho')
-            # rho, u = macro(f_1, rho, u)
-            # wp.synchronize()
-            # wp.synchronize()
-            # u.update_host(0)
-            # rho.update_host(0)
-            # wp.synchronize()
-            # u.export_vti("u_f1_init.vti", 'u')
-            # rho.export_vti("rho_f1_init.vti", 'rho')
         # Important note: XLB uses f_1 buffer (center index and missing directions) to store auxiliary data for boundary conditions.
-
         # Process boundary conditions and update masks
         f_1, bc_mask, missing_mask = self._process_boundary_conditions(self.boundary_conditions, f_1, bc_mask, missing_mask)
 
@@ -131,6 +96,14 @@ class IncompressibleNavierStokesStepper(Stepper):
         wp.synchronize()
         # bc_mask.export_vti("bc_mask.vti", 'bc_mask')
         # missing_mask.export_vti("missing_mask.vti", 'missing_mask')
+
+        # Initialize distribution functions if initializer is provided
+        if initializer is not None:
+            f_0 = initializer(bc_mask, f_0)
+        else:
+            from xlb.helper.initializers import initialize_eq
+
+            f_0 = initialize_eq(f_0, self.grid, self.velocity_set, self.precision_policy, self.compute_backend)
 
         return f_0, f_1, bc_mask, missing_mask
 

--- a/xlb/utils/mesher.py
+++ b/xlb/utils/mesher.py
@@ -154,7 +154,7 @@ class ExportMultiresHDF5(object):
         assert coordinates.size != 0, "Error: No valid data to process. Check the input levels_data."
 
         # Merge duplicate points
-        coordinates, connectivity = self._merge_duplicates(coordinates, connectivity)
+        coordinates, connectivity = self._merge_duplicates(coordinates, connectivity, levels_data)
 
         # Apply scale and offset
         coordinates = self._transform_coordinates(coordinates, scale, offset)
@@ -331,7 +331,7 @@ class ExportMultiresHDF5(object):
             for fname, fdata in field_data.items():
                 fg.create_dataset(fname, data=fdata.astype(np.float32), compression=compression, compression_opts=compression_opts)
 
-    def _merge_duplicates(self, coordinates, connectivity):
+    def _merge_duplicates(self, coordinates, connectivity, levels_data):
         # Merging duplicate points
         tolerance = 0.01
         chunk_size = 10_000_000  # Adjust based on GPU memory
@@ -340,13 +340,17 @@ class ExportMultiresHDF5(object):
         mapping = np.zeros(num_points, dtype=np.int32)
         unique_idx = 0
 
+        # Get the grid shape of computational box at the finest level from the levels_data
+        num_levels = len(levels_data)
+        grid_shape_finest = np.array(levels_data[-1][0].shape) * 2 ** (num_levels - 1)
+
         for start in range(0, num_points, chunk_size):
             end = min(start + chunk_size, num_points)
             coords_chunk = coordinates[start:end]
 
             # Simple hashing: grid coordinates as tuple keys
             grid_coords = np.round(coords_chunk / tolerance).astype(np.int64)
-            hash_keys = grid_coords[:, 0] + grid_coords[:, 1] * 1_000_000 + grid_coords[:, 2] * 1_000_000_000_000
+            hash_keys = grid_coords[:, 0] + grid_coords[:, 1] * grid_shape_finest[0] + grid_coords[:, 2] * grid_shape_finest[0] * grid_shape_finest[1]
             unique_hash, inverse = np.unique(hash_keys, return_inverse=True)
             unique_hash, unique_indices, inverse = np.unique(hash_keys, return_index=True, return_inverse=True)
             unique_chunk = coords_chunk[unique_indices]

--- a/xlb/utils/mesher.py
+++ b/xlb/utils/mesher.py
@@ -346,9 +346,7 @@ class ExportMultiresHDF5(object):
 
             # Simple hashing: grid coordinates as tuple keys
             grid_coords = np.round(coords_chunk / tolerance).astype(np.int64)
-            hash_keys = (grid_coords[:, 0] +
-                         grid_coords[:, 1] * 1_000_000 +
-                         grid_coords[:, 2] * 1_000_000_000_000)
+            hash_keys = grid_coords[:, 0] + grid_coords[:, 1] * 1_000_000 + grid_coords[:, 2] * 1_000_000_000_000
             unique_hash, inverse = np.unique(hash_keys, return_inverse=True)
             unique_hash, unique_indices, inverse = np.unique(hash_keys, return_index=True, return_inverse=True)
             unique_chunk = coords_chunk[unique_indices]


### PR DESCRIPTION
## Contributing Guidelines

<!-- Please make sure you have read and understood our contributing guidelines before submitting this PR -->
- [x] I have read and understood the [CONTRIBUTING.md](https://github.com/Autodesk/XLB/blob/main/CONTRIBUTING.md) guidelines


## Description
Added a helper initializer class that sets assines equilibrium values for populations with non-zero velocity only at the outlet. This class was used before (in dense) in the `rotating_sphere_3d.py` and is now used in multi-res in the `cuboid_flow_past sphere.py` example

<!-- 
Thank you for your contribution! Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->


## Type of change

<!-- Please select the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Include details of your test environment, and the test cases you ran.

- [ ] Test A
- [ ] Test B
-->
- [x] All pytest tests pass

<!-- To run the tests, execute the following command from the root of the repository:

```bash
pytest
```
 -->


## Linting and Code Formatting

Make sure the code follows the project's linting and formatting standards. This project uses **Ruff** for linting.

To run Ruff, execute the following command from the root of the repository:

```bash
ruff check .
```

<!-- You can also fix some linting errors automatically using Ruff:

```bash
ruff check . --fix
```
-->

- [x] Ruff passes
