### PR TITLE
Uses only device memory for LBM population fields in Neon.

### DIFF
--- a/xlb/operator/stepper/nse_multires_stepper.py
+++ b/xlb/operator/stepper/nse_multires_stepper.py
@@ -63,11 +63,11 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
         """
 
         f_0 = self.grid.create_field(
-            cardinality=self.velocity_set.q, dtype=self.precision_policy.store_precision, neon_memory_type=neon.MemoryType.host_device()
+            cardinality=self.velocity_set.q, dtype=self.precision_policy.store_precision, neon_memory_type=neon.MemoryType.device()
         )
 
         f_1 = self.grid.create_field(
-            cardinality=self.velocity_set.q, dtype=self.precision_policy.store_precision, neon_memory_type=neon.MemoryType.host_device()
+            cardinality=self.velocity_set.q, dtype=self.precision_policy.store_precision, neon_memory_type=neon.MemoryType.device()
         )
 
         missing_mask = self.grid.create_field(cardinality=self.velocity_set.q, dtype=Precision.UINT8)


### PR DESCRIPTION
Changes the memory type used for fields f_0 and f_1 to device memory only.
