### PR TITLE
Fixed the missing mask in MRES 

### DIFF
--- a/examples/cfd/grid_refinement/cuboid_flow_past_sphere_3d.py
+++ b/examples/cfd/grid_refinement/cuboid_flow_past_sphere_3d.py
@@ -211,7 +211,7 @@ bc_left = RegularizedBC("velocity", profile=bc_profile(), indices=inlet)
 # bc_left = HybridBC(bc_method="bounceback_regularized", profile=bc_profile(), indices=inlet)
 # Alternatively, use a prescribed velocity profile
 # bc_left = RegularizedBC("velocity", prescribed_value=(u_max, 0.0, 0.0), indices=inlet)
-bc_walls = FullwayBounceBackBC(indices=walls)  # TODO: issues with halfway bounce back only here!
+bc_walls = HalfwayBounceBackBC(indices=walls)
 # bc_ground = FullwayBounceBackBC(indices=grid.boundary_indices_across_levels(level_data, box_side="front"))
 # bc_outlet = ExtrapolationOutflowBC(indices=outlet)
 bc_outlet = DoNothingBC(indices=outlet)

--- a/examples/cfd/grid_refinement/flow_past_sphere_3d.py
+++ b/examples/cfd/grid_refinement/flow_past_sphere_3d.py
@@ -136,7 +136,7 @@ def bc_profile():
 bc_left = RegularizedBC("velocity", profile=bc_profile(), indices=inlet)
 # Alternatively, use a prescribed velocity profile
 # bc_left = RegularizedBC("velocity", prescribed_value=(u_max, 0.0, 0.0), indices=inlet)
-bc_walls = FullwayBounceBackBC(indices=walls)  # TODO: issues with halfway bounce back only here!
+bc_walls = FullwayBounceBackBC(indices=walls)
 # bc_outlet = ExtrapolationOutflowBC(indices=outlet)
 bc_outlet = DoNothingBC(indices=outlet)
 bc_sphere = HalfwayBounceBackBC(indices=sphere)

--- a/xlb/operator/boundary_masker/helper_functions_masker.py
+++ b/xlb/operator/boundary_masker/helper_functions_masker.py
@@ -66,11 +66,14 @@ class HelperFunctionsMasker(object):
             field: Any,
             lattice_dir: wp.int32,
             index: wp.vec3i,
+            level: Any,
         ):
             pull_index = wp.vec3i()
             offset = wp.vec3i()
             for d in range(self.velocity_set.d):
                 offset[d] = -_c[d, lattice_dir]
+                for _ in range(level):
+                    offset[d] *= 2
                 pull_index[d] = index[d] + offset[d]
 
             return pull_index, offset
@@ -80,10 +83,11 @@ class HelperFunctionsMasker(object):
             field: Any,
             lattice_dir: wp.int32,
             index: Any,
+            level: Any,
         ):
             # Convert the index to warp
             index_wp = neon_index_to_warp(field, index)
-            pull_index_wp, _ = get_pull_index_warp(field, lattice_dir, index_wp)
+            pull_index_wp, _ = get_pull_index_warp(field, lattice_dir, index_wp, level)
             offset = wp.neon_ngh_idx(wp.int8(-_c[0, lattice_dir]), wp.int8(-_c[1, lattice_dir]), wp.int8(-_c[2, lattice_dir]))
             return pull_index_wp, offset
 

--- a/xlb/operator/boundary_masker/indices_boundary_masker.py
+++ b/xlb/operator/boundary_masker/indices_boundary_masker.py
@@ -145,6 +145,7 @@ class IndicesBoundaryMasker(Operator):
             bc_mask: Any,
             missing_mask: Any,
             grid_shape: Any,
+            level: Any = 0,
         ):
             for ii in range(bc_indices.shape[1]):
                 # If the current index does not match the boundary condition index, we skip it
@@ -164,7 +165,7 @@ class IndicesBoundaryMasker(Operator):
                 # Stream indices
                 for l in range(_q):
                     # Get the pull index which is the index of the neighboring node where information is pulled from
-                    pull_index, _ = self.helper_masker.get_pull_index(bc_mask, l, index)
+                    pull_index, _ = self.helper_masker.get_pull_index(bc_mask, l, index, level)
 
                     # Check if pull index is out of bound
                     # These directions will have missing information after streaming
@@ -193,6 +194,7 @@ class IndicesBoundaryMasker(Operator):
             bc_mask: Any,
             missing_mask: Any,
             grid_shape: Any,
+            level: Any = 0,
         ):
             for ii in range(bc_indices.shape[1]):
                 # If the current index does not match the boundary condition index, we skip it
@@ -200,7 +202,7 @@ class IndicesBoundaryMasker(Operator):
                     continue
                 for l in range(_q):
                     # Get the index of the streaming direction
-                    pull_index, offset = self.helper_masker.get_pull_index(bc_mask, l, index)
+                    pull_index, offset = self.helper_masker.get_pull_index(bc_mask, l, index, level)
 
                     # Check if pull index is a fluid node (bc_mask is zero for fluid nodes)
                     bc_mask_ngh = self.read_field_neighbor(bc_mask, index, offset, 0)

--- a/xlb/operator/boundary_masker/multires_indices_boundary_masker.py
+++ b/xlb/operator/boundary_masker/multires_indices_boundary_masker.py
@@ -61,6 +61,7 @@ class MultiresIndicesBoundaryMasker(IndicesBoundaryMasker):
                         bc_mask_pn,
                         missing_mask_pn,
                         grid_shape,
+                        level,
                     )
 
                 loader.declare_kernel(domain_bounds_kernel)
@@ -114,6 +115,7 @@ class MultiresIndicesBoundaryMasker(IndicesBoundaryMasker):
                         bc_mask_pn,
                         missing_mask_pn,
                         grid_shape,
+                        level,
                     )
 
                 loader.declare_kernel(interior_missing_mask_kernel)


### PR DESCRIPTION
The missing mask was incorrect for +x, +y and +z bounds and as a result those boundaries could not have non fullway BCs that would rely on missing directions. 