### PR TITLE
Mesh voxelization method

### DIFF
--- a/examples/cfd/grid_refinement/cuboid_flow_past_sphere_3d.py
+++ b/examples/cfd/grid_refinement/cuboid_flow_past_sphere_3d.py
@@ -215,9 +215,9 @@ bc_walls = HalfwayBounceBackBC(indices=walls)
 # bc_ground = FullwayBounceBackBC(indices=grid.boundary_indices_across_levels(level_data, box_side="front"))
 # bc_outlet = ExtrapolationOutflowBC(indices=outlet)
 bc_outlet = DoNothingBC(indices=outlet)
-# bc_sphere = HalfwayBounceBackBC(mesh_vertices=sphere, voxelization_method=MeshVoxelizationMethod.AABB)
+# bc_sphere = HalfwayBounceBackBC(mesh_vertices=sphere, voxelization_method=MeshVoxelizationMethod('AABB'))
 bc_sphere = HybridBC(
-    bc_method="nonequilibrium_regularized", mesh_vertices=sphere, voxelization_method=MeshVoxelizationMethod.AABB, use_mesh_distance=True
+    bc_method="nonequilibrium_regularized", mesh_vertices=sphere, voxelization_method=MeshVoxelizationMethod("AABB"), use_mesh_distance=True
 )
 
 boundary_conditions = [bc_walls, bc_left, bc_outlet, bc_sphere]

--- a/examples/cfd/rotating_sphere_3d.py
+++ b/examples/cfd/rotating_sphere_3d.py
@@ -130,7 +130,7 @@ bc_sphere = HybridBC(
     bc_method="nonequilibrium_regularized",
     mesh_vertices=sphere,
     use_mesh_distance=True,
-    voxelization_method=MeshVoxelizationMethod.RAY,
+    voxelization_method=MeshVoxelizationMethod("RAY"),
     profile=bc_profile(),
 )
 # Not assining BC for walls makes them periodic.

--- a/examples/cfd/windtunnel_3d.py
+++ b/examples/cfd/windtunnel_3d.py
@@ -75,7 +75,7 @@ walls = np.unique(np.array(walls), axis=-1).tolist()
 
 # Load the mesh (replace with your own mesh)
 stl_filename = "../stl-files/DrivAer-Notchback.stl"
-voxelization_method = MeshVoxelizationMethod.RAY
+voxelization_method = MeshVoxelizationMethod("RAY")
 mesh = trimesh.load_mesh(stl_filename, process=False)
 mesh_vertices = mesh.vertices
 
@@ -90,9 +90,9 @@ mesh_vertices = mesh_vertices / dx
 # Depending on the voxelization method, shift_z ensures the bottom ground does not intersect with the voxelized mesh
 # Any smaller shift value would lead to large lift computations due to the initial equilibrium distributions. Bigger
 # values would be fine but leave a gap between surfaces that are supposed to touch.
-if voxelization_method in (MeshVoxelizationMethod.RAY, MeshVoxelizationMethod.WINDING):
+if voxelization_method in (MeshVoxelizationMethod("RAY"), MeshVoxelizationMethod("WINDING")):
     shift_z = 2
-elif voxelization_method in (MeshVoxelizationMethod.AABB, MeshVoxelizationMethod.AABB_CLOSE):
+elif voxelization_method in (MeshVoxelizationMethod("AABB"), MeshVoxelizationMethod("AABB_CLOSE", close_voxels=3)):
     shift_z = 3
 shift = np.array([grid_shape[0] / 4, (grid_shape[1] - mesh_extents[1] / dx) / 2, shift_z])
 car_vertices = mesh_vertices + shift

--- a/xlb/operator/boundary_masker/aabb_close.py
+++ b/xlb/operator/boundary_masker/aabb_close.py
@@ -21,8 +21,11 @@ class MeshMaskerAABBClose(MeshBoundaryMasker):
         velocity_set: VelocitySet = None,
         precision_policy: PrecisionPolicy = None,
         compute_backend: ComputeBackend = None,
-        close_voxels: int = 3,
+        close_voxels: int = None,
     ):
+        assert close_voxels is not None, (
+            "Please provide the number of close voxels using the 'close_voxels' argument! e.g., MeshVoxelizationMethod('AABB_CLOSE', close_voxels=3)"
+        )
         self.close_voxels = close_voxels
         # Call super
         self.tile_half = close_voxels

--- a/xlb/operator/boundary_masker/mesh_voxelization_method.py
+++ b/xlb/operator/boundary_masker/mesh_voxelization_method.py
@@ -1,10 +1,24 @@
-# Enum used to keep track of the available voxelization methods
+# A class used to keep track of the available voxelization methods
 
-from enum import Enum, auto
+from dataclasses import dataclass
 
 
-class MeshVoxelizationMethod(Enum):
-    AABB = auto()
-    RAY = auto()
-    AABB_CLOSE = auto()
-    WINDING = auto()
+# Registry
+METHODS = {
+    "AABB": 1,
+    "RAY": 2,
+    "AABB_CLOSE": 3,
+    "WINDING": 4,
+}
+
+
+@dataclass
+class VoxelizationMethod:
+    id: int
+    name: str
+    options: dict
+
+
+def MeshVoxelizationMethod(name: str, **options):
+    assert name in METHODS.keys(), f"Unsupported voxelization method: {name}"
+    return VoxelizationMethod(METHODS[name], name, options)

--- a/xlb/operator/boundary_masker/multires_aabb_close.py
+++ b/xlb/operator/boundary_masker/multires_aabb_close.py
@@ -22,7 +22,7 @@ class MultiresMeshMaskerAABBClose(MeshMaskerAABBClose):
         velocity_set: VelocitySet = None,
         precision_policy: PrecisionPolicy = None,
         compute_backend: ComputeBackend = None,
-        close_voxels: int = 4,
+        close_voxels: int = None,
     ):
         super().__init__(velocity_set, precision_policy, compute_backend, close_voxels)
         if self.compute_backend in [ComputeBackend.JAX, ComputeBackend.WARP]:

--- a/xlb/operator/macroscopic/multires_macroscopic.py
+++ b/xlb/operator/macroscopic/multires_macroscopic.py
@@ -55,11 +55,6 @@ class MultiresMacroscopic(Macroscopic):
 
                     _rho, _u = functional(_f)
 
-                    if _boundary_id != wp.uint8(0):
-                        _rho = self.compute_dtype(1.0)
-                        for d in range(_d):
-                            _u[d] = self.compute_dtype(0.0)
-
                     if _boundary_id == wp.uint8(255) or wp.neon_has_child(f, gIdx):
                         _rho = self.compute_dtype(0.0)
                         for d in range(_d):

--- a/xlb/operator/stepper/nse_multires_stepper.py
+++ b/xlb/operator/stepper/nse_multires_stepper.py
@@ -230,17 +230,18 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
         # Process mesh-based boundary conditions for 3D
         if DefaultConfig.velocity_set.d == 3 and bc_with_vertices:
             for bc in bc_with_vertices:
-                if bc.voxelization_method is MeshVoxelizationMethod.AABB:
+                if bc.voxelization_method.id is MeshVoxelizationMethod("AABB").id:
                     mesh_masker = MultiresMeshMaskerAABB(
                         velocity_set=DefaultConfig.velocity_set,
                         precision_policy=DefaultConfig.default_precision_policy,
                         compute_backend=DefaultConfig.default_backend,
                     )
-                elif bc.voxelization_method is MeshVoxelizationMethod.AABB_CLOSE:
+                elif bc.voxelization_method.id is MeshVoxelizationMethod("AABB_CLOSE").id:
                     mesh_masker = MultiresMeshMaskerAABBClose(
                         velocity_set=DefaultConfig.velocity_set,
                         precision_policy=DefaultConfig.default_precision_policy,
                         compute_backend=DefaultConfig.default_backend,
+                        close_voxels=bc.voxelization_method.options.get("close_voxels"),
                     )
                 else:
                     raise ValueError(f"Unsupported voxelization method for multi-res: {bc.voxelization_method}")

--- a/xlb/operator/stepper/nse_stepper.py
+++ b/xlb/operator/stepper/nse_stepper.py
@@ -135,29 +135,30 @@ class IncompressibleNavierStokesStepper(Stepper):
         # Process mesh-based boundary conditions for 3D
         if DefaultConfig.velocity_set.d == 3 and bc_with_vertices:
             for bc in bc_with_vertices:
-                if bc.voxelization_method is MeshVoxelizationMethod.AABB:
+                if bc.voxelization_method.id is MeshVoxelizationMethod("AABB").id:
                     mesh_masker = MeshMaskerAABB(
                         velocity_set=DefaultConfig.velocity_set,
                         precision_policy=DefaultConfig.default_precision_policy,
                         compute_backend=DefaultConfig.default_backend,
                     )
-                elif bc.voxelization_method is MeshVoxelizationMethod.RAY:
+                elif bc.voxelization_method.id is MeshVoxelizationMethod("RAY").id:
                     mesh_masker = MeshMaskerRay(
                         velocity_set=DefaultConfig.velocity_set,
                         precision_policy=DefaultConfig.default_precision_policy,
                         compute_backend=DefaultConfig.default_backend,
                     )
-                elif bc.voxelization_method is MeshVoxelizationMethod.WINDING:
+                elif bc.voxelization_method.id is MeshVoxelizationMethod("WINDING").id:
                     mesh_masker = MeshMaskerWinding(
                         velocity_set=DefaultConfig.velocity_set,
                         precision_policy=DefaultConfig.default_precision_policy,
                         compute_backend=DefaultConfig.default_backend,
                     )
-                elif bc.voxelization_method is MeshVoxelizationMethod.AABB_CLOSE:
+                elif bc.voxelization_method.id is MeshVoxelizationMethod("AABB_CLOSE").id:
                     mesh_masker = MeshMaskerAABBClose(
                         velocity_set=DefaultConfig.velocity_set,
                         precision_policy=DefaultConfig.default_precision_policy,
                         compute_backend=DefaultConfig.default_backend,
+                        close_voxels=bc.voxelization_method.options.get("close_voxels"),
                     )
                 else:
                     raise ValueError(f"Unsupported voxelization method: {bc.voxelization_method}")


### PR DESCRIPTION
- Changed the mesh voxelization method from an enum to a callabale function with a name and options. This way `close_voxels`  can be used as an input for example:

`MeshVoxelizationMethod('AABB_CLOSE', close_voxels=3)`

- I also removed the hardcoded zero-ing of veloity in the multires macroscopic container.