### PR TITLE
Omega must vary across resolutions to maintain viscosity as a constant

### DIFF
--- a/examples/cfd/grid_refinement/cuboid_flow_past_sphere_3d.py
+++ b/examples/cfd/grid_refinement/cuboid_flow_past_sphere_3d.py
@@ -224,7 +224,7 @@ boundary_conditions = [bc_walls, bc_left, bc_outlet, bc_sphere]
 
 # Configure the simulation relaxation time
 visc = u_max * num_finest_voxels_across_part / Re
-omega = 1.0 / (3.0 * visc + 0.5)
+omega_finest = 1.0 / (3.0 * visc + 0.5)
 
 # Make initializer operator
 from xlb.helper.initializers import CustomMultiresInitializer
@@ -239,7 +239,7 @@ initializer = CustomMultiresInitializer(
 
 # Define a multi-resolution simulation manager
 sim = xlb.helper.MultiresSimulationManager(
-    omega=omega,
+    omega_finest=omega_finest,
     grid=grid,
     boundary_conditions=boundary_conditions,
     collision_type="KBC",

--- a/examples/cfd/grid_refinement/flow_past_sphere_3d.py
+++ b/examples/cfd/grid_refinement/flow_past_sphere_3d.py
@@ -145,11 +145,11 @@ boundary_conditions = [bc_walls, bc_left, bc_outlet, bc_sphere]
 
 # Configure the simulation relaxation time
 visc = 2.0 * u_max * sphere_radius / Re
-omega = 1.0 / (3.0 * visc + 0.5)
+omega_finest = 1.0 / (3.0 * visc + 0.5)
 
 # Define a multi-resolution simulation manager
 sim = xlb.helper.MultiresSimulationManager(
-    omega=omega,
+    omega_finest=omega_finest,
     grid=grid,
     boundary_conditions=boundary_conditions,
     collision_type="BGK",

--- a/examples/performance/mlups_3d_multires.py
+++ b/examples/performance/mlups_3d_multires.py
@@ -192,10 +192,10 @@ def run(velocity_set, grid_shape, num_steps):
     Re = 5000.0
     clength = grid_shape[0] - 1
     visc = prescribed_vel * clength / Re
-    omega = 1.0 / (3.0 * visc + 0.5)
+    omega_finest = 1.0 / (3.0 * visc + 0.5)
 
     # Define a multi-resolution simulation manager
-    sim = xlb.helper.MultiresSimulationManager(omega=omega, grid=grid, boundary_conditions=boundary_conditions, collision_type="KBC")
+    sim = xlb.helper.MultiresSimulationManager(omega_finest=omega_finest, grid=grid, boundary_conditions=boundary_conditions, collision_type="KBC")
 
     # sim.export_macroscopic("Initial_")
     # sim.step()

--- a/xlb/helper/simulation_manager.py
+++ b/xlb/helper/simulation_manager.py
@@ -12,7 +12,7 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
 
     def __init__(
         self,
-        omega,
+        omega_finest,
         grid,
         boundary_conditions=[],
         collision_type="BGK",
@@ -24,8 +24,8 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
         super().__init__(grid, boundary_conditions, collision_type, forcing_scheme, force_vector)
 
         self.initializer = initializer
-        self.omega = omega
         self.count_levels = grid.count_levels
+        self.omega_list = [self.compute_omega(omega_finest, level) for level in range(self.count_levels)]
         self.mres_perf_opt = mres_perf_opt
         # Create fields
         self.rho = grid.create_field(cardinality=1, dtype=self.precision_policy.store_precision)
@@ -51,6 +51,27 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
         # Construct the stepper skeleton
         self._construct_stepper_skeleton()
 
+    def compute_omega(self, omega_finest, level):
+        """
+        Compute the relaxation parameter omega at a given grid level based on the finest level omega.
+        We select a refinement ratio of 2 where a coarse cell at level L is uniformly divided into 2^d cells
+        where d is the dimension. to arrive at level L - 1, or in other words ∆x_{L-1} = ∆x_L/2.
+        For neighboring cells that interface two grid levels, a maximum jump in grid level of ∆L = 1 is
+        allowed. Due to acoustic scaling which requires the speed of sound cs to remain constant across various grid levels,
+        ∆tL ∝ ∆xL and hence ∆t_{L-1} = ∆t_{L}/2. In addition, the fluid viscosity \nu must also remain constant on each
+        grid level which leads to the following relationship for the relaxation parameter omega at grid level L base
+        on the finest grid level omega_finest.
+
+        Args:
+            omega_finest: Relaxation parameter at the finest grid level.
+            level: Current grid level (0-indexed, with 0 being the finest level).
+
+        Returns:
+            Relaxation parameter omega at the specified grid level.
+        """
+        omega0 = omega_finest
+        return 2 ** (level + 1) * omega0 / ((2**level - 1.0) * omega0 + 2.0)
+
     def export_macroscopic(self, fname_prefix):
         print(f"exporting macroscopic: #levels {self.count_levels}")
         self.macro(self.f_0, self.bc_mask, self.rho, self.u, streamId=0)
@@ -74,6 +95,10 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
         def recursion_reference(level, app):
             if level < 0:
                 return
+
+            # Compute omega at the current level
+            omega = self.omega_list[level]
+
             print(f"RECURSION down to level {level}")
             print(f"RECURSION Level {level}, COLLIDE")
 
@@ -85,7 +110,7 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
                 f_1=self.f_1,
                 bc_mask=self.bc_mask,
                 missing_mask=self.missing_mask,
-                omega=self.omega,
+                omega=omega,
                 timestep=0,
             )
 
@@ -110,6 +135,9 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
             if level < 0:
                 return
 
+            # Compute omega at the current level
+            omega = self.omega_list[level]
+
             if level == 0:
                 print(f"RECURSION down to the finest level {level}")
                 print(f"RECURSION Level {level}, Fused STREAM and COLLIDE")
@@ -121,7 +149,7 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
                     f_1=self.f_1,
                     bc_mask=self.bc_mask,
                     missing_mask=self.missing_mask,
-                    omega=self.omega,
+                    omega=omega,
                     timestep=0,
                     is_f1_the_explosion_src_field=True,
                 )
@@ -133,7 +161,7 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
                     f_1=self.f_0,
                     bc_mask=self.bc_mask,
                     missing_mask=self.missing_mask,
-                    omega=self.omega,
+                    omega=omega,
                     timestep=0,
                     is_f1_the_explosion_src_field=False,
                 )
@@ -150,7 +178,7 @@ class MultiresSimulationManager(MultiresIncompressibleNavierStokesStepper):
                 f_1=self.f_1,
                 bc_mask=self.bc_mask,
                 missing_mask=self.missing_mask,
-                omega=self.omega,
+                omega=omega,
                 timestep=0,
             )
             # 1. Accumulation is read from f_0 in the streaming step, where f_0=self.f_1.


### PR DESCRIPTION
So far we were not scaling the relaxation parameter (omega) properly across various levels. This PR fixes this.