### PR TITLE
Fixed KBC bug

### DIFF
--- a/examples/cfd/grid_refinement/cuboid_flow_past_sphere_3d.py
+++ b/examples/cfd/grid_refinement/cuboid_flow_past_sphere_3d.py
@@ -186,7 +186,7 @@ bc_left = RegularizedBC("velocity", profile=bc_profile(), indices=inlet)
 # bc_left = HybridBC(bc_method="bounceback_regularized", profile=bc_profile(), indices=inlet)
 # Alternatively, use a prescribed velocity profile
 # bc_left = RegularizedBC("velocity", prescribed_value=(u_max, 0.0, 0.0), indices=inlet)
-bc_walls = HalfwayBounceBackBC(indices=walls)
+bc_walls = FullwayBounceBackBC(indices=walls)
 # bc_ground = FullwayBounceBackBC(indices=grid.boundary_indices_across_levels(level_data, box_side="front"))
 # bc_outlet = ExtrapolationOutflowBC(indices=outlet)
 bc_outlet = DoNothingBC(indices=outlet)

--- a/tests/kernels/collision/test_bgk_collision_jax.py
+++ b/tests/kernels/collision/test_bgk_collision_jax.py
@@ -45,7 +45,7 @@ def test_bgk_ollision(dim, velocity_set, grid_shape, omega):
 
     f_orig = my_grid.create_field(cardinality=DefaultConfig.velocity_set.q)
 
-    f_out = compute_collision(f_orig, f_eq, rho, u, omega)
+    f_out = compute_collision(f_orig, f_eq, omega)
 
     assert jnp.allclose(f_out, f_orig - omega * (f_orig - f_eq))
 

--- a/tests/kernels/collision/test_bgk_collision_warp.py
+++ b/tests/kernels/collision/test_bgk_collision_warp.py
@@ -44,7 +44,7 @@ def test_bgk_collision_warp(dim, velocity_set, grid_shape, omega):
     f_orig = my_grid.create_field(cardinality=DefaultConfig.velocity_set.q)
 
     f_out = my_grid.create_field(cardinality=DefaultConfig.velocity_set.q)
-    f_out = compute_collision(f_orig, f_eq, f_out, rho, u, omega)
+    f_out = compute_collision(f_orig, f_eq, f_out, omega)
 
     f_eq = f_eq.numpy()
     f_out = f_out.numpy()

--- a/xlb/operator/boundary_masker/indices_boundary_masker.py
+++ b/xlb/operator/boundary_masker/indices_boundary_masker.py
@@ -284,7 +284,7 @@ class IndicesBoundaryMasker(Operator):
         }
         return functional_dict, kernel_dict
 
-    def _prepare_kernel_inputs(self, bclist, grid_shape):
+    def _prepare_kernel_inputs(self, bclist, grid_shape, start_index=None):
         """
         Prepare the inputs for the warp kernel by pre-allocating arrays and filling them with boundary condition information.
         """
@@ -371,7 +371,7 @@ class IndicesBoundaryMasker(Operator):
         bc_interior = self._find_bclist_interior(bclist, grid_shape)
 
         # Prepare the first kernel inputs for all items in boundary condition list
-        wp_bc_indices, wp_id_numbers, wp_is_interior = self._prepare_kernel_inputs(bclist, grid_shape)
+        wp_bc_indices, wp_id_numbers, wp_is_interior = self._prepare_kernel_inputs(bclist, grid_shape, start_index)
 
         # Launch the warp kernel
         wp.launch(
@@ -523,7 +523,7 @@ class IndicesBoundaryMasker(Operator):
         bc_interior = self._find_bclist_interior(bclist, grid_shape)
 
         # Prepare the first kernel inputs for all items in boundary condition list
-        wp_bc_indices, wp_id_numbers, wp_is_interior = self._prepare_kernel_inputs(bclist, grid_shape)
+        wp_bc_indices, wp_id_numbers, wp_is_interior = self._prepare_kernel_inputs(bclist, grid_shape, start_index)
 
         # Launch the first container
         container_domain_bounds = self.neon_container["container_domain_bounds"](

--- a/xlb/operator/collision/bgk.py
+++ b/xlb/operator/collision/bgk.py
@@ -16,7 +16,7 @@ class BGK(Collision):
 
     @Operator.register_backend(ComputeBackend.JAX)
     @partial(jit, static_argnums=(0,))
-    def jax_implementation(self, f: jnp.ndarray, feq: jnp.ndarray, rho, u, omega):
+    def jax_implementation(self, f: jnp.ndarray, feq: jnp.ndarray, omega):
         fneq = f - feq
         fout = f - self.compute_dtype(omega) * fneq
         return fout
@@ -28,7 +28,7 @@ class BGK(Collision):
 
         # Construct the functional
         @wp.func
-        def functional(f: Any, feq: Any, rho: Any, u: Any, omega: Any):
+        def functional(f: Any, feq: Any, omega: Any):
             fneq = f - feq
             fout = f - self.compute_dtype(omega) * fneq
             return fout
@@ -39,8 +39,6 @@ class BGK(Collision):
             f: wp.array4d(dtype=Any),
             feq: wp.array4d(dtype=Any),
             fout: wp.array4d(dtype=Any),
-            rho: wp.array4d(dtype=Any),
-            u: wp.array4d(dtype=Any),
             omega: Any,
         ):
             # Get the global index
@@ -55,7 +53,7 @@ class BGK(Collision):
                 _feq[l] = feq[l, index[0], index[1], index[2]]
 
             # Compute the collision
-            _fout = functional(_f, _feq, rho, u, omega)
+            _fout = functional(_f, _feq, omega)
 
             # Write the result
             for l in range(self.velocity_set.q):
@@ -68,7 +66,7 @@ class BGK(Collision):
         return functional, None
 
     @Operator.register_backend(ComputeBackend.WARP)
-    def warp_implementation(self, f, feq, fout, rho, u, omega):
+    def warp_implementation(self, f, feq, fout, omega):
         # Launch the warp kernel
         wp.launch(
             self.warp_kernel,
@@ -76,8 +74,6 @@ class BGK(Collision):
                 f,
                 feq,
                 fout,
-                rho,
-                u,
                 omega,
             ],
             dim=f.shape[1:],

--- a/xlb/operator/collision/forced_collision.py
+++ b/xlb/operator/collision/forced_collision.py
@@ -33,9 +33,9 @@ class ForcedCollision(Collision):
 
     @Operator.register_backend(ComputeBackend.JAX)
     @partial(jit, static_argnums=(0,))
-    def jax_implementation(self, f: jnp.ndarray, feq: jnp.ndarray, rho, u, omega):
-        fout = self.collision_operator(f, feq, rho, u, omega)
-        fout = self.forcing_operator(fout, feq, rho, u)
+    def jax_implementation(self, f: jnp.ndarray, feq: jnp.ndarray, omega):
+        fout = self.collision_operator(f, feq, omega)
+        fout = self.forcing_operator(fout, feq)
         return fout
 
     def _construct_warp(self):
@@ -45,9 +45,9 @@ class ForcedCollision(Collision):
 
         # Construct the functional
         @wp.func
-        def functional(f: Any, feq: Any, rho: Any, u: Any, omega: Any):
-            fout = self.collision_operator.warp_functional(f, feq, rho, u, omega)
-            fout = self.forcing_operator.warp_functional(fout, feq, rho, u)
+        def functional(f: Any, feq: Any, omega: Any):
+            fout = self.collision_operator.warp_functional(f, feq, omega)
+            fout = self.forcing_operator.warp_functional(fout, feq)
             return fout
 
         # Construct the warp kernel
@@ -56,8 +56,6 @@ class ForcedCollision(Collision):
             f: wp.array4d(dtype=Any),
             feq: wp.array4d(dtype=Any),
             fout: wp.array4d(dtype=Any),
-            rho: wp.array4d(dtype=Any),
-            u: wp.array4d(dtype=Any),
             omega: Any,
         ):
             # Get the global index
@@ -71,13 +69,9 @@ class ForcedCollision(Collision):
             for l in range(self.velocity_set.q):
                 _f[l] = f[l, index[0], index[1], index[2]]
                 _feq[l] = feq[l, index[0], index[1], index[2]]
-            _u = _u_vec()
-            for l in range(_d):
-                _u[l] = u[l, index[0], index[1], index[2]]
-            _rho = rho[0, index[0], index[1], index[2]]
 
             # Compute the collision
-            _fout = functional(_f, _feq, _rho, _u, omega)
+            _fout = functional(_f, _feq, omega)
 
             # Write the result
             for l in range(self.velocity_set.q):
@@ -86,7 +80,7 @@ class ForcedCollision(Collision):
         return functional, kernel
 
     @Operator.register_backend(ComputeBackend.WARP)
-    def warp_implementation(self, f, feq, fout, rho, u, omega):
+    def warp_implementation(self, f, feq, fout, omega):
         # Launch the warp kernel
         wp.launch(
             self.warp_kernel,
@@ -94,8 +88,6 @@ class ForcedCollision(Collision):
                 f,
                 feq,
                 fout,
-                rho,
-                u,
                 omega,
             ],
             dim=f.shape[1:],

--- a/xlb/operator/collision/kbc.py
+++ b/xlb/operator/collision/kbc.py
@@ -43,8 +43,6 @@ class KBC(Collision):
         self,
         f: jnp.ndarray,
         feq: jnp.ndarray,
-        rho: jnp.ndarray,
-        u: jnp.ndarray,
         omega,
     ):
         """
@@ -56,10 +54,6 @@ class KBC(Collision):
             Distribution function.
         feq : jax.numpy.array
             Equilibrium distribution function.
-        rho : jax.numpy.array
-            Density.
-        u : jax.numpy.array
-            Velocity.
         """
         fneq = f - feq
         if isinstance(self.velocity_set, D2Q9):
@@ -269,8 +263,6 @@ class KBC(Collision):
         def functional(
             f: Any,
             feq: Any,
-            rho: Any,
-            u: Any,
             omega: Any,
         ):
             # Compute shear and delta_s
@@ -301,8 +293,6 @@ class KBC(Collision):
             f: wp.array4d(dtype=Any),
             feq: wp.array4d(dtype=Any),
             fout: wp.array4d(dtype=Any),
-            rho: wp.array4d(dtype=Any),
-            u: wp.array4d(dtype=Any),
             omega: Any,
         ):
             # Get the global index
@@ -316,13 +306,9 @@ class KBC(Collision):
             for l in range(self.velocity_set.q):
                 _f[l] = f[l, index[0], index[1], index[2]]
                 _feq[l] = feq[l, index[0], index[1], index[2]]
-            _u = _u_vec()
-            for l in range(_d):
-                _u[l] = u[l, index[0], index[1], index[2]]
-            _rho = rho[0, index[0], index[1], index[2]]
 
             # Compute the collision
-            _fout = functional(_f, _feq, _rho, _u, omega)
+            _fout = functional(_f, _feq, omega)
 
             # Write the result
             for l in range(self.velocity_set.q):
@@ -338,7 +324,7 @@ class KBC(Collision):
         return functional, None
 
     @Operator.register_backend(ComputeBackend.WARP)
-    def warp_implementation(self, f, feq, fout, rho, u, omega):
+    def warp_implementation(self, f, feq, fout, omega):
         # Launch the warp kernel
         wp.launch(
             self.warp_kernel,
@@ -346,8 +332,6 @@ class KBC(Collision):
                 f,
                 feq,
                 fout,
-                rho,
-                u,
                 omega,
             ],
             dim=f.shape[1:],

--- a/xlb/operator/collision/kbc.py
+++ b/xlb/operator/collision/kbc.py
@@ -64,10 +64,10 @@ class KBC(Collision):
         fneq = f - feq
         if isinstance(self.velocity_set, D2Q9):
             shear = self.decompose_shear_d2q9_jax(fneq)
-            delta_s = shear * rho / 4.0
+            delta_s = shear / 4.0
         elif isinstance(self.velocity_set, D3Q27):
             shear = self.decompose_shear_d3q27_jax(fneq)
-            delta_s = shear * rho
+            delta_s = shear
         else:
             raise NotImplementedError("Velocity set not supported: {}".format(type(self.velocity_set)))
 
@@ -277,10 +277,10 @@ class KBC(Collision):
             fneq = f - feq
             if wp.static(self.velocity_set.d == 3):
                 shear = decompose_shear_d3q27(fneq)
-                delta_s = shear * rho
+                delta_s = shear
             else:
                 shear = decompose_shear_d2q9(fneq)
-                delta_s = shear * rho / self.compute_dtype(4.0)
+                delta_s = shear / self.compute_dtype(4.0)
 
             # Compute required constants based on the input omega (omega is the inverse relaxation time)
             _beta = self.compute_dtype(0.5) * self.compute_dtype(omega)

--- a/xlb/operator/collision/smagorinsky_les_bgk.py
+++ b/xlb/operator/collision/smagorinsky_les_bgk.py
@@ -28,7 +28,7 @@ class SmagorinskyLESBGK(Collision):
 
     @Operator.register_backend(ComputeBackend.JAX)
     @partial(jit, static_argnums=(0,))
-    def jax_implementation(self, f: jnp.ndarray, feq: jnp.ndarray, rho: jnp.ndarray, u: jnp.ndarray, omega):
+    def jax_implementation(self, f: jnp.ndarray, feq: jnp.ndarray, omega):
         fneq = f - feq
 
         pi_neq = jnp.tensordot(self.velocity_set.cc, fneq, axes=(0, 0))
@@ -65,8 +65,6 @@ class SmagorinskyLESBGK(Collision):
         def functional(
             f: Any,
             feq: Any,
-            rho: Any,
-            u: Any,
             omega: Any,
         ):
             # Compute the non-equilibrium distribution
@@ -127,8 +125,6 @@ class SmagorinskyLESBGK(Collision):
         def kernel(
             f: wp.array4d(dtype=Any),
             feq: wp.array4d(dtype=Any),
-            rho: wp.array4d(dtype=Any),
-            u: wp.array4d(dtype=Any),
             fout: wp.array4d(dtype=Any),
             omega: wp.float32,
         ):
@@ -142,13 +138,9 @@ class SmagorinskyLESBGK(Collision):
             for l in range(self.velocity_set.q):
                 _f[l] = f[l, index[0], index[1], index[2]]
                 _feq[l] = feq[l, index[0], index[1], index[2]]
-            _u = _u_vec()
-            for l in range(_d):
-                _u[l] = u[l, index[0], index[1], index[2]]
-            _rho = rho[0, index[0], index[1], index[2]]
 
             # Compute the collision
-            _fout = functional(_f, _feq, _rho, _u, omega)
+            _fout = functional(_f, _feq, omega)
 
             # Write the result
             for l in range(self.velocity_set.q):
@@ -157,15 +149,13 @@ class SmagorinskyLESBGK(Collision):
         return functional, kernel
 
     @Operator.register_backend(ComputeBackend.WARP)
-    def warp_implementation(self, f, feq, rho, u, fout, omega):
+    def warp_implementation(self, f, feq, fout, omega):
         # Launch the warp kernel
         wp.launch(
             self.warp_kernel,
             inputs=[
                 f,
                 feq,
-                rho,
-                u,
                 fout,
                 omega,
             ],

--- a/xlb/operator/stepper/nse_multires_stepper.py
+++ b/xlb/operator/stepper/nse_multires_stepper.py
@@ -408,7 +408,7 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
 
                         _rho, _u = self.macroscopic.neon_functional(_f_post_stream)
                         _feq = self.equilibrium.neon_functional(_rho, _u)
-                        _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, _rho, _u, omega)
+                        _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, omega)
 
                         # Apply post-collision boundary conditions
                         _f_post_collision = apply_bc(
@@ -474,7 +474,7 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
 
                     _rho, _u = self.macroscopic.neon_functional(_f_post_stream)
                     _feq = self.equilibrium.neon_functional(_rho, _u)
-                    _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, _rho, _u, omega)
+                    _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, omega)
 
                     for l in range(self.velocity_set.q):
                         wp.neon_write(f_1_pn, index, l, _f_post_collision[l])
@@ -532,7 +532,7 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
 
                         _rho, _u = self.macroscopic.neon_functional(_f_post_stream)
                         _feq = self.equilibrium.neon_functional(_rho, _u)
-                        _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, _rho, _u, omega)
+                        _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, omega)
 
                         # Apply post-collision boundary conditions
                         _f_post_collision = apply_bc(
@@ -1125,7 +1125,7 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
 
                     _rho, _u = self.macroscopic.neon_functional(_f_post_stream)
                     _feq = self.equilibrium.neon_functional(_rho, _u)
-                    _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, _rho, _u, omega)
+                    _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, omega)
 
                     # Apply post-collision boundary conditions
                     _f_post_collision = apply_bc(
@@ -1242,7 +1242,7 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
 
                     _rho, _u = self.macroscopic.neon_functional(_f_post_stream)
                     _feq = self.equilibrium.neon_functional(_rho, _u)
-                    _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, _rho, _u, omega)
+                    _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, omega)
 
                     # Apply post-collision boundary conditions
                     _f_post_collision = apply_bc(
@@ -1307,7 +1307,7 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
 
                     _rho, _u = self.macroscopic.neon_functional(_f_post_stream)
                     _feq = self.equilibrium.neon_functional(_rho, _u)
-                    _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, _rho, _u, omega)
+                    _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, omega)
 
                     for l in range(self.velocity_set.q):
                         wp.neon_write(f_1_pn, index, l, _f_post_collision[l])

--- a/xlb/operator/stepper/nse_stepper.py
+++ b/xlb/operator/stepper/nse_stepper.py
@@ -234,7 +234,7 @@ class IncompressibleNavierStokesStepper(Stepper):
         feq = self.equilibrium(rho, u)
 
         # Apply collision
-        f_post_collision = self.collision(f_post_stream, feq, rho, u, omega)
+        f_post_collision = self.collision(f_post_stream, feq, omega)
 
         # Apply collision type boundary conditions
         for bc in self.boundary_conditions:
@@ -271,7 +271,7 @@ class IncompressibleNavierStokesStepper(Stepper):
         feq = self.equilibrium(rho, u)
 
         # Apply collision
-        f_post_collision = self.collision(f_post_stream, feq, rho, u, omega)
+        f_post_collision = self.collision(f_post_stream, feq, omega)
 
         # Apply collision type boundary conditions
         for bc in self.boundary_conditions:
@@ -422,7 +422,7 @@ class IncompressibleNavierStokesStepper(Stepper):
 
             _rho, _u = self.macroscopic.warp_functional(_f_post_stream)
             _feq = self.equilibrium.warp_functional(_rho, _u)
-            _f_post_collision = self.collision.warp_functional(_f_post_stream, _feq, _rho, _u, omega)
+            _f_post_collision = self.collision.warp_functional(_f_post_stream, _feq, omega)
 
             # Apply post-collision boundary conditions
             _f_post_collision = apply_bc(index, timestep, _boundary_id, _missing_mask, f_0, f_1, _f_post_stream, _f_post_collision, False)
@@ -578,7 +578,7 @@ class IncompressibleNavierStokesStepper(Stepper):
 
                     _rho, _u = self.macroscopic.neon_functional(_f_post_stream)
                     _feq = self.equilibrium.neon_functional(_rho, _u)
-                    _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, _rho, _u, omega)
+                    _f_post_collision = self.collision.neon_functional(_f_post_stream, _feq, omega)
 
                     # Apply post-collision boundary conditions
                     _f_post_collision = apply_bc(


### PR DESCRIPTION
MomentumFlux operator already returns a value which has rho embedded by definition. Due to confusing notation in some papers, I had an additional multiplication by rho in the KBC. This bug is fixed now and I cleaned up the signature of all collision functionals and kernels to exclude unnecessary passing of rho and u.