### PR TITLE
(install) extend XLB install for the Neon backend.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.xlb-env/
 
 # Spyder project settings
 .spyderproject

--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 Mehdi Ataei (Autodesk Inc)
 Hesam Saleipour (Autodesk Inc)
 Oliver Hennigh (NVIDIA)
+Massimiliano Meneghin (Autodesk Inc)

--- a/README.md
+++ b/README.md
@@ -35,15 +35,16 @@ pip install "xlb[tpu]"
 ```
 
 ### Installation with Neon support
-Neon backend enables multi-GPU dense and single-GPU multi-resolution representations. Install XLB with Neon support using:
+Neon backend enables multi-GPU dense and single-GPU multi-resolution representations. 
+Install XLB with Neon support using:
 
 ```bash
 pip install "xlb[neon]"
 ```
 
-**Requirements:** The Neon wheel is built only for **Python 3.12** on **Linux x86_64**. If you see "not a supported wheel on this platform", switch to Python 3.12 (e.g. `pyenv install 3.12` or a conda env with Python 3.12). The wheel also requires GLIBC >= 2.38 (e.g., Ubuntu 24.04 or later).
+**Requirements:** The Neon wheel supports **Python 3.11** to **Python 3.11** on **Linux x86_64**. Porting on ARM is on the way.
 
-**Note:** Neon uses a custom fork of warp. When you install from source, `warp-lang` is uninstalled automatically if present. When installing from a pre-built wheel, uninstall warp first if needed: `pip uninstall warp-lang`. Set `XLB_NEON_SKIP_UNINSTALL_WARP=1` to skip automatic uninstall.
+**Note:** Neon uses a custom fork of warp.
 
 ### Notes:
 - For Mac users: Use the basic CPU installation command as JAX's GPU support is not available on MacOS

--- a/README.md
+++ b/README.md
@@ -39,10 +39,13 @@ Neon backend enables multi-GPU dense and single-GPU multi-resolution representat
 Install XLB with Neon support using:
 
 ```bash
-pip install "xlb[neon]"
+git clone https://github.com/Autodesk/XLB.git
+cd XLB
+pip install -r requirements.txt
+pip install '.[neon]'
 ```
 
-**Requirements:** The Neon wheel supports **Python 3.11** to **Python 3.11** on **Linux x86_64**. Porting on ARM is on the way.
+**Requirements:** The Neon wheel supports **Python 3.11** to **Python 3.11** on **Linux x86_64** and **Linux ARM**. 
 
 **Note:** Neon uses a custom fork of warp.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ To get started with XLB, you can install it using pip. There are different insta
 pip install xlb
 ```
 
+### Installation with Warp support (single-GPU)
+For the NVIDIA Warp backend (single-GPU, state-of-the-art performance):
+```bash
+pip install "xlb[warp]"
+```
+
 ### Installation with CUDA support (for NVIDIA GPUs)
 This installation is for the JAX backend with CUDA support:
 ```bash
@@ -28,19 +34,20 @@ This installation is for the JAX backend with TPU support:
 pip install "xlb[tpu]"
 ```
 
-### Installation with Neon support 
-Neon backend enables multi-GPU dense and single-GPU multi-resolution representations. Neon depends on a custom fork of warp-lang, so any existing warp installation must be removed before installing Neon. The Python interface for Neon can be installed from a pre-built wheel hosted on GitHub. Note that the wheel currently requires GLIBC >= 2.38 (e.g., Ubuntu 24.04 or later).
+### Installation with Neon support
+Neon backend enables multi-GPU dense and single-GPU multi-resolution representations. Install XLB with Neon support using:
 
 ```bash
-pip uninstall warp-lang
-pip install https://github.com/Autodesk/Neon/releases/download/v0.5.2a1/neon_gpu-0.5.2a1-cp312-cp312-linux_x86_64.whl
+pip install "xlb[neon]"
 ```
 
+**Requirements:** The Neon wheel is built only for **Python 3.12** on **Linux x86_64**. If you see "not a supported wheel on this platform", switch to Python 3.12 (e.g. `pyenv install 3.12` or a conda env with Python 3.12). The wheel also requires GLIBC >= 2.38 (e.g., Ubuntu 24.04 or later).
 
+**Note:** Neon uses a custom fork of warp. When you install from source, `warp-lang` is uninstalled automatically if present. When installing from a pre-built wheel, uninstall warp first if needed: `pip uninstall warp-lang`. Set `XLB_NEON_SKIP_UNINSTALL_WARP=1` to skip automatic uninstall.
 
 ### Notes:
 - For Mac users: Use the basic CPU installation command as JAX's GPU support is not available on MacOS
-- The NVIDIA Warp backend is included in all installation options and supports CUDA automatically when available
+- Use `xlb[warp]` for the Warp backend (single-GPU) or `xlb[neon]` for the Neon backend (multi-GPU / multi-resolution). Do not install both in the same environment.
 - The installation options for CUDA and TPU only affect the JAX backend
 
 To install the latest development version from source:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install -r requirements.txt
 pip install '.[neon]'
 ```
 
-**Requirements:** The Neon wheel supports **Python 3.11** to **Python 3.11** on **Linux x86_64** and **Linux ARM**. 
+**Requirements:** The Neon wheel supports **Python 3.11** to **Python 3.14** on **Linux x86_64** and **Linux ARM**. 
 
 **Note:** Neon uses a custom fork of warp.
 

--- a/examples/cfd/multires_flow_past_sphere_3d.py
+++ b/examples/cfd/multires_flow_past_sphere_3d.py
@@ -11,6 +11,7 @@ try:
     import neon
 except ModuleNotFoundError:
     import sys
+
     raise ModuleNotFoundError(
         "The 'neon' module is required for this example (Neon backend). "
         "Install with: pip install 'xlb[neon]'. "

--- a/examples/cfd/multires_flow_past_sphere_3d.py
+++ b/examples/cfd/multires_flow_past_sphere_3d.py
@@ -7,7 +7,16 @@ Uses AABB-Close voxelization with halfway bounce-back on the sphere surface and
 computes lift/drag via momentum transfer.
 """
 
-import neon
+try:
+    import neon
+except ModuleNotFoundError:
+    import sys
+    raise ModuleNotFoundError(
+        "The 'neon' module is required for this example (Neon backend). "
+        "Install with: pip install 'xlb[neon]'. "
+        f"You are on Python {sys.version_info.major}.{sys.version_info.minor}; "
+        "the current Neon wheel requires Python 3.11 or 3.12. Use an appropriate environment (e.g. pyenv, conda, or venv)."
+    ) from None
 import warp as wp
 import numpy as np
 import time

--- a/examples/performance/mlups_3d.py
+++ b/examples/performance/mlups_3d.py
@@ -25,7 +25,7 @@ def parse_arguments():
 
     parser = argparse.ArgumentParser(
         description="MLUPS Benchmark for 3D Lattice Boltzmann Method Simulation",
-        epilog=f"""
+        epilog="""
 Examples:
   %(prog)s 100 1000 neon fp32/fp32
   %(prog)s 200 500 neon fp64/fp64 --collision_model KBC --velocity_set D3Q27

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ numpy
 pyvista
 Rtree
 trimesh
-warp-lang
 numpy-stl
 pydantic
 nvtx

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import subprocess
 import sys
 
@@ -35,10 +36,12 @@ _NEON_RELEASE_URL = f"https://github.com/Autodesk/Neon/releases/download/v{_NEON
 def _neon_wheel_requirement():
     """Build a direct-reference requirement for the neon_gpu wheel matching the running Python."""
     tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
-    wheel = f"neon_gpu-{_NEON_VERSION}-{tag}-{tag}-linux_x86_64.whl"
+    machine = platform.machine()
+    plat = "linux_aarch64" if machine == "aarch64" else "linux_x86_64"
+    wheel = f"neon_gpu-{_NEON_VERSION}-{tag}-{tag}-{plat}.whl"
     url = f"{_NEON_RELEASE_URL}/{wheel}"
     req = f"neon_gpu @ {url}"
-    print(f"[xlb] Neon wheel for Python {sys.version_info.major}.{sys.version_info.minor}: {url}")
+    print(f"[xlb] Neon wheel for Python {sys.version_info.major}.{sys.version_info.minor} ({plat}): {url}")
     print(f"[xlb] Neon requirement: {req}")
     return req
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,63 @@
+import os
+import subprocess
+import sys
+
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+
+
+def _neon_extra_requested():
+    """Best-effort detection of [neon] extra from install invocation."""
+    for arg in sys.argv:
+        if "neon" in arg and ("[" in arg or "xlb" in arg):
+            return True
+    return False
+
+
+def _uninstall_warp_lang():
+    """Uninstall warp-lang so Neon's custom warp fork can be used."""
+    if os.environ.get("XLB_NEON_SKIP_UNINSTALL_WARP", "").lower() in ("1", "true", "yes"):
+        return
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "uninstall", "warp-lang", "-y"],
+            check=False,
+            capture_output=True,
+        )
+    except Exception:
+        pass
+
+
+_NEON_WHEEL_DIR = "/home/max/repo/neon_warp_testing/neon/dist-multi"
+
+
+def _neon_wheel_requirement():
+    """Build a direct-reference requirement for the neon_gpu wheel matching the running Python.
+
+    Always returns a file:// URL. If the wheel doesn't exist, pip will error
+    at install time with a clear "file not found" when the [neon] extra is
+    requested. Non-neon installs never trigger the download so they are safe.
+    """
+    tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    wheel = f"neon_gpu-0.5.2a1-{tag}-{tag}-linux_x86_64.whl"
+    path = os.path.join(_NEON_WHEEL_DIR, wheel)
+    return f"neon_gpu @ file://{path}"
+
+
+class InstallWithNeonHooks(install):
+    """After install, uninstall warp-lang when [neon] extra was requested.
+
+    Only runs when installing from source (e.g. sdist or git). Wheel installs
+    do not run setup.py, so for ``pip install xlb[neon]`` from PyPI you may
+    need to run ``pip uninstall warp-lang`` first if it is already installed.
+    Set XLB_NEON_SKIP_UNINSTALL_WARP=1 to disable this behaviour.
+    """
+
+    def run(self):
+        install.run(self)
+        if _neon_extra_requested():
+            _uninstall_warp_lang()
+
 
 setup(
     name="xlb",
@@ -15,17 +74,20 @@ setup(
         "numpy>=2.1.2",
         "pyvista>=0.44.1",
         "trimesh>=4.4.9",
-        "warp-lang>=1.10.0",
         "numpy-stl>=3.1.2",
         "pydantic>=2.9.1",
         "ruff>=0.14.1",
         "jax>=0.8.2",  # Base JAX CPU-only requirement
     ],
     extras_require={
+        "warp": ["warp-lang>=1.10.0"],  # Warp backend (single-GPU); included by default for full backend support
         "cuda": ["jax[cuda13]>=0.8.2"],  # For CUDA installations (pip install -U "jax[cuda13]")
         "tpu": ["jax[tpu]>=0.8.2"],  # For TPU installations
+        # TEMPORARY: local wheel resolved dynamically for the running Python version.
+        "neon": [_neon_wheel_requirement()],
         "test": ["pytest>=8.0.0"],
     },
     python_requires=">=3.11",
     dependency_links=["https://storage.googleapis.com/jax-releases/libtpu_releases.html"],
+    cmdclass={"install": InstallWithNeonHooks},
 )

--- a/setup.py
+++ b/setup.py
@@ -28,20 +28,19 @@ def _uninstall_warp_lang():
         pass
 
 
-_NEON_WHEEL_DIR = "/home/max/repo/neon_warp_testing/neon/dist-multi"
+_NEON_VERSION = "0.5.2a1"
+_NEON_RELEASE_URL = f"https://github.com/Autodesk/Neon/releases/download/v{_NEON_VERSION}"
 
 
 def _neon_wheel_requirement():
-    """Build a direct-reference requirement for the neon_gpu wheel matching the running Python.
-
-    Always returns a file:// URL. If the wheel doesn't exist, pip will error
-    at install time with a clear "file not found" when the [neon] extra is
-    requested. Non-neon installs never trigger the download so they are safe.
-    """
+    """Build a direct-reference requirement for the neon_gpu wheel matching the running Python."""
     tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
-    wheel = f"neon_gpu-0.5.2a1-{tag}-{tag}-linux_x86_64.whl"
-    path = os.path.join(_NEON_WHEEL_DIR, wheel)
-    return f"neon_gpu @ file://{path}"
+    wheel = f"neon_gpu-{_NEON_VERSION}-{tag}-{tag}-linux_x86_64.whl"
+    url = f"{_NEON_RELEASE_URL}/{wheel}"
+    req = f"neon_gpu @ {url}"
+    print(f"[xlb] Neon wheel for Python {sys.version_info.major}.{sys.version_info.minor}: {url}")
+    print(f"[xlb] Neon requirement: {req}")
+    return req
 
 
 class InstallWithNeonHooks(install):
@@ -83,7 +82,6 @@ setup(
         "warp": ["warp-lang>=1.10.0"],  # Warp backend (single-GPU); included by default for full backend support
         "cuda": ["jax[cuda13]>=0.8.2"],  # For CUDA installations (pip install -U "jax[cuda13]")
         "tpu": ["jax[tpu]>=0.8.2"],  # For TPU installations
-        # TEMPORARY: local wheel resolved dynamically for the running Python version.
         "neon": [_neon_wheel_requirement()],
         "test": ["pytest>=8.0.0"],
     },

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ def _uninstall_warp_lang():
             check=False,
             capture_output=True,
         )
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001
+        print(f"[xlb] Warning: failed to uninstall warp-lang: {exc}")
 
 
 _NEON_VERSION = "0.5.2a1"

--- a/xlb/helper/initializers.py
+++ b/xlb/helper/initializers.py
@@ -248,6 +248,8 @@ class CustomInitializer(Operator):
 
     @Operator.register_backend(ComputeBackend.NEON)
     def neon_implementation(self, bc_mask, f_field, stream=0):
+        import neon
+
         # Launch the neon container
         c = self.neon_container(bc_mask, f_field)
         c.run(stream, container_runtime=neon.Container.ContainerRuntime.neon)
@@ -274,6 +276,8 @@ class CustomMultiresInitializer(CustomInitializer):
         super().__init__(constant_velocity_vector, constant_density, bc_id, initialization_operator, velocity_set, precision_policy, compute_backend)
 
     def _construct_neon(self):
+        import neon
+
         # Use the warp functional for the NEON backend
         functional, _ = self._construct_warp()
 
@@ -301,6 +305,7 @@ class CustomMultiresInitializer(CustomInitializer):
 
     @Operator.register_backend(ComputeBackend.NEON)
     def neon_implementation(self, bc_mask, f_field, stream=0):
+        import neon
         grid = bc_mask.get_grid()
         for level in range(grid.num_levels):
             # Launch the neon container

--- a/xlb/helper/initializers.py
+++ b/xlb/helper/initializers.py
@@ -306,6 +306,7 @@ class CustomMultiresInitializer(CustomInitializer):
     @Operator.register_backend(ComputeBackend.NEON)
     def neon_implementation(self, bc_mask, f_field, stream=0):
         import neon
+
         grid = bc_mask.get_grid()
         for level in range(grid.num_levels):
             # Launch the neon container

--- a/xlb/operator/boundary_condition/helper_functions_bc.py
+++ b/xlb/operator/boundary_condition/helper_functions_bc.py
@@ -555,6 +555,8 @@ class EncodeAuxiliaryData(Operator):
 
     @Operator.register_backend(ComputeBackend.NEON)
     def neon_implementation(self, f_1, bc_mask, missing_mask):
+        import neon
+
         c = self.neon_container(f_1, bc_mask, missing_mask)
         c.run(0, container_runtime=neon.Container.ContainerRuntime.neon)
         return f_1
@@ -589,6 +591,7 @@ class MultiresEncodeAuxiliaryData(EncodeAuxiliaryData):
         """
         Constructs the Neon container for encoding auxiliary data recovery.
         """
+        import neon
 
         # Borrow the functional from the warp implementation
         functional_dict, _ = self._construct_warp()
@@ -635,6 +638,7 @@ class MultiresEncodeAuxiliaryData(EncodeAuxiliaryData):
 
     @Operator.register_backend(ComputeBackend.NEON)
     def neon_implementation(self, f_1, bc_mask, missing_mask, stream):
+        import neon
         grid = bc_mask.get_grid()
         for level in range(grid.num_levels):
             c = self.neon_container(f_1, bc_mask, missing_mask, level)

--- a/xlb/operator/boundary_condition/helper_functions_bc.py
+++ b/xlb/operator/boundary_condition/helper_functions_bc.py
@@ -639,6 +639,7 @@ class MultiresEncodeAuxiliaryData(EncodeAuxiliaryData):
     @Operator.register_backend(ComputeBackend.NEON)
     def neon_implementation(self, f_1, bc_mask, missing_mask, stream):
         import neon
+
         grid = bc_mask.get_grid()
         for level in range(grid.num_levels):
             c = self.neon_container(f_1, bc_mask, missing_mask, level)

--- a/xlb/operator/boundary_condition/helper_functions_bc.py
+++ b/xlb/operator/boundary_condition/helper_functions_bc.py
@@ -620,9 +620,9 @@ class MultiresEncodeAuxiliaryData(EncodeAuxiliaryData):
 
                     # Apply the functional
                     if _boundary_id == _id:
-                        # IMPORTANT NOTE:
-                        # It is assumed in XLB that the user_defined_functional in multi-res simulations is defined in terms of the indices at the finest level.
-                        # This assumption enables handling of BCs whose indices span multiple levels
+                        # IMPORTANT: XLB assumes the user_defined_functional in multi-res
+                        # simulations uses finest-level indices, enabling BCs that span
+                        # multiple levels.
                         warp_index = self.bc_helper.neon_index_to_warp(f_1_pn, index)
                         prescribed_values = self.user_defined_functional(warp_index)
 

--- a/xlb/operator/boundary_masker/aabb.py
+++ b/xlb/operator/boundary_masker/aabb.py
@@ -189,6 +189,7 @@ class MeshMaskerAABB(MeshBoundaryMasker):
         bc_mask,
         missing_mask,
     ):
+        import neon
         # Prepare inputs
         mesh_id, bc_id = self._prepare_kernel_inputs(bc, bc_mask)
 

--- a/xlb/operator/boundary_masker/indices_boundary_masker.py
+++ b/xlb/operator/boundary_masker/indices_boundary_masker.py
@@ -528,6 +528,7 @@ class IndicesBoundaryMasker(Operator):
 
     @Operator.register_backend(ComputeBackend.NEON)
     def neon_implementation(self, bclist, bc_mask, missing_mask, start_index=None):
+        import neon
         # get the grid shape
         grid_shape = self.helper_masker.get_grid_shape(bc_mask)
 

--- a/xlb/operator/boundary_masker/multires_aabb.py
+++ b/xlb/operator/boundary_masker/multires_aabb.py
@@ -39,6 +39,8 @@ class MultiresMeshMaskerAABB(MeshMaskerAABB):
             raise NotImplementedError(f"Operator {self.__class__.__name__} not supported in {self.compute_backend} backend.")
 
     def _construct_neon(self):
+        import neon
+
         # Use the warp functional for the NEON backend
         functional, _ = self._construct_warp()
 

--- a/xlb/operator/boundary_masker/multires_aabb_close.py
+++ b/xlb/operator/boundary_masker/multires_aabb_close.py
@@ -227,6 +227,8 @@ class MultiresMeshMaskerAABBClose(MeshMaskerAABBClose):
         missing_mask,
         stream=0,
     ):
+        import neon
+
         # Prepare inputs
         mesh_id, bc_id = self._prepare_kernel_inputs(bc, bc_mask)
 

--- a/xlb/operator/boundary_masker/multires_indices_boundary_masker.py
+++ b/xlb/operator/boundary_masker/multires_indices_boundary_masker.py
@@ -35,6 +35,8 @@ class MultiresIndicesBoundaryMasker(IndicesBoundaryMasker):
             raise NotImplementedError(f"Operator {self.__class__.__name__} not supported in {self.compute_backend} backend.")
 
     def _construct_neon(self):
+        import neon
+
         # Use the warp functional for the NEON backend
         functional_dict, _ = self._construct_warp()
         functional_domain_bounds = functional_dict.get("functional_domain_bounds")

--- a/xlb/operator/boundary_masker/multires_ray.py
+++ b/xlb/operator/boundary_masker/multires_ray.py
@@ -30,6 +30,8 @@ class MultiresMeshMaskerRay(MeshMaskerRay):
             raise NotImplementedError(f"Operator {self.__class__.__name__} not supported in {self.compute_backend} backend.")
 
     def _construct_neon(self):
+        import neon
+
         # Use the warp functional for the NEON backend
         functional, _ = self._construct_warp()
 

--- a/xlb/operator/boundary_masker/ray.py
+++ b/xlb/operator/boundary_masker/ray.py
@@ -167,6 +167,7 @@ class MeshMaskerRay(MeshBoundaryMasker):
         missing_mask,
     ):
         # Prepare inputs
+        import neon
         mesh_id, bc_id = self._prepare_kernel_inputs(bc, bc_mask)
 
         # Launch the appropriate neon container

--- a/xlb/operator/equilibrium/multires_quadratic_equilibrium.py
+++ b/xlb/operator/equilibrium/multires_quadratic_equilibrium.py
@@ -68,6 +68,8 @@ class MultiresQuadraticEquilibrium(QuadraticEquilibrium):
 
     @Operator.register_backend(ComputeBackend.NEON)
     def neon_implementation(self, rho, u, f, stream=0):
+        import neon
+
         grid = f.get_grid()
         for level in range(grid.num_levels):
             c = self.neon_container(rho, u, f, level)

--- a/xlb/operator/equilibrium/quadratic_equilibrium.py
+++ b/xlb/operator/equilibrium/quadratic_equilibrium.py
@@ -124,7 +124,7 @@ class QuadraticEquilibrium(Equilibrium):
                 f_pn = loader.get_write_handle(f)
 
                 @wp.func
-                def quadratic_equilibrium_cl(index: typing.Any):
+                def quadratic_equilibrium_cl(index: Any):
                     _u = _u_vec()
                     for d in range(self.velocity_set.d):
                         _u[d] = self.compute_dtype(wp.neon_read(u_pn, index, d))
@@ -143,6 +143,8 @@ class QuadraticEquilibrium(Equilibrium):
 
     @Operator.register_backend(ComputeBackend.NEON)
     def neon_implementation(self, rho, u, f):
+        import neon
+
         c = self.neon_container(rho, u, f)
         c.run(0, container_runtime=neon.Container.ContainerRuntime.neon)
         return f

--- a/xlb/operator/force/momentum_transfer.py
+++ b/xlb/operator/force/momentum_transfer.py
@@ -350,6 +350,8 @@ class MomentumTransfer(Operator):
         missing_mask,
         stream=0,
     ):
+        import neon
+
         # Ensure the force is initialized to zero
         self.force *= self.compute_dtype(0.0)
 

--- a/xlb/operator/force/multires_momentum_transfer.py
+++ b/xlb/operator/force/multires_momentum_transfer.py
@@ -123,6 +123,8 @@ class MultiresMomentumTransfer(MomentumTransfer):
         missing_mask,
         stream=0,
     ):
+        import neon
+
         # Ensure the force is initialized to zero
         self.force *= self.compute_dtype(0.0)
 

--- a/xlb/operator/macroscopic/macroscopic.py
+++ b/xlb/operator/macroscopic/macroscopic.py
@@ -91,7 +91,7 @@ class Macroscopic(Operator):
                 f = loader.get_read_handle(f_field)
 
                 @wp.func
-                def macroscopic_cl(gIdx: typing.Any):
+                def macroscopic_cl(gIdx: Any):
                     _f = _f_vec()
                     for l in range(self.velocity_set.q):
                         _f[l] = self.compute_dtype(wp.neon_read(f, gIdx, l))

--- a/xlb/operator/macroscopic/multires_macroscopic.py
+++ b/xlb/operator/macroscopic/multires_macroscopic.py
@@ -56,7 +56,7 @@ class MultiresMacroscopic(Macroscopic):
                 bc_mask_pn = loader.get_mres_read_handle(bc_mask)
 
                 @wp.func
-                def macroscopic_cl(gIdx: typing.Any):
+                def macroscopic_cl(gIdx: Any):
                     _f = _f_vec()
                     _boundary_id = wp.neon_read(bc_mask_pn, gIdx, 0)
 

--- a/xlb/operator/stepper/nse_multires_stepper.py
+++ b/xlb/operator/stepper/nse_multires_stepper.py
@@ -220,6 +220,7 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
         bc_mask : field
             Boundary-condition mask used to skip solid voxels.
         """
+        import neon
         lattice_central_index = self.velocity_set.center_index
         num_levels = coalescence_factor.get_grid().num_levels
 
@@ -380,6 +381,8 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
         return f_1
 
     def _construct_neon(self):
+        import neon
+
         # Pre-capture self attributes that Warp cannot resolve inside @wp.func bodies.
         # Warp rejects `self` as an "Invalid external reference type" when it appears
         # in a plain assignment (e.g. `_c = self.velocity_set.c`).  Capturing here

--- a/xlb/operator/stepper/nse_multires_stepper.py
+++ b/xlb/operator/stepper/nse_multires_stepper.py
@@ -1176,7 +1176,7 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
         try:
             op_name = kwargs.pop("op_name")
             app = kwargs.pop("app")
-        except:
+        except KeyError:
             raise ValueError("op_name and app must be provided as keyword arguments")
 
         try:

--- a/xlb/operator/stepper/nse_multires_stepper.py
+++ b/xlb/operator/stepper/nse_multires_stepper.py
@@ -221,6 +221,7 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
             Boundary-condition mask used to skip solid voxels.
         """
         import neon
+
         lattice_central_index = self.velocity_set.center_index
         num_levels = coalescence_factor.get_grid().num_levels
 

--- a/xlb/operator/stepper/nse_stepper.py
+++ b/xlb/operator/stepper/nse_stepper.py
@@ -636,6 +636,7 @@ class IncompressibleNavierStokesStepper(Stepper):
 
     def prepare_skeleton(self, f_0, f_1, bc_mask, missing_mask, omega):
         """Build the Neon odd/even skeletons for double-buffered time stepping."""
+        import neon
         grid = f_0.get_grid()
         bk = grid.backend
         self.neon_skeleton = {"odd": {}, "even": {}}

--- a/xlb/utils/mesher.py
+++ b/xlb/utils/mesher.py
@@ -521,6 +521,7 @@ class MultiresIO(object):
         Extracts and prepares the fields data from the NEON fields for export.
         """
         import neon
+
         # Check if the field_neon_dict is empty
         if not field_neon_dict:
             return {}

--- a/xlb/utils/mesher.py
+++ b/xlb/utils/mesher.py
@@ -520,6 +520,7 @@ class MultiresIO(object):
         """
         Extracts and prepares the fields data from the NEON fields for export.
         """
+        import neon
         # Check if the field_neon_dict is empty
         if not field_neon_dict:
             return {}


### PR DESCRIPTION
## Contributing Guidelines

- [X ] I have read and understood the [CONTRIBUTING.md](https://github.com/Autodesk/XLB/blob/main/CONTRIBUTING.md) guidelines


## Description

Automatic installation of Neon wheels for x86 and ARM


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [X] Running multi-res examples
- [X] All pytest tests pass

```
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/max/repo/XLB
collected 93 items                                                                                                                                                     

tests/boundary_conditions/bc_equilibrium/test_bc_equilibrium_jax.py ....                                                                                         [  4%]
tests/boundary_conditions/bc_equilibrium/test_bc_equilibrium_warp.py ....                                                                                        [  8%]
tests/boundary_conditions/bc_fullway_bounce_back/test_bc_fullway_bounce_back_jax.py ......                                                                       [ 15%]
tests/boundary_conditions/bc_fullway_bounce_back/test_bc_fullway_bounce_back_warp.py ......                                                                      [ 21%]
tests/boundary_conditions/mask/test_bc_indices_masker_jax.py .......                                                                                             [ 29%]
tests/boundary_conditions/mask/test_bc_indices_masker_warp.py ......                                                                                             [ 35%]
tests/grids/test_grid_jax.py .......                                                                                                                             [ 43%]
tests/grids/test_grid_warp.py ....                                                                                                                               [ 47%]
tests/kernels/collision/test_bgk_collision_jax.py ......                                                                                                         [ 53%]
tests/kernels/collision/test_bgk_collision_warp.py ......                                                                                                        [ 60%]
tests/kernels/equilibrium/test_equilibrium_jax.py ......                                                                                                         [ 66%]
tests/kernels/equilibrium/test_equilibrium_warp.py ......                                                                                                        [ 73%]
tests/kernels/macroscopic/test_macroscopic_jax.py ......                                                                                                         [ 79%]
tests/kernels/macroscopic/test_macroscopic_warp.py .......                                                                                                       [ 87%]
tests/kernels/stream/test_stream_jax.py ......                                                                                                                   [ 93%]
tests/kernels/stream/test_stream_warp.py ......                                                                                                                  [100%]

==================================================================== 93 passed in 232.35s (0:03:52) ====================================================================
```

## Linting and Code Formatting

- [X] Ruff passes
